### PR TITLE
121 more better

### DIFF
--- a/SirenOfShame.Lib/Util/BuildStatusUtil.cs
+++ b/SirenOfShame.Lib/Util/BuildStatusUtil.cs
@@ -17,12 +17,12 @@ namespace SirenOfShame.Lib.Util
             var oldBuildStatusesToRetain = oldBuildStatuses.Except(newBuildStatuses, buildStatusComparer);
             var newBuildStatusesToAdd = newBuildStatuses.Except(oldBuildStatuses, buildStatusComparer);
             var unchangedBuildStatuses = from oldStatus in oldBuildStatuses
-                                         join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
+                                         join newStatus in newBuildStatuses on oldStatus.UniqueId equals newStatus.UniqueId
                                          where newStatus.BuildStatusEnum == oldStatus.BuildStatusEnum &&
                                             newStatus.StartedTime == oldStatus.StartedTime
                                          select oldStatus;
             var changedBuildStatuses = from oldStatus in oldBuildStatuses
-                                       join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
+                                       join newStatus in newBuildStatuses on oldStatus.UniqueId equals newStatus.UniqueId
                                        where newStatus.BuildStatusEnum != oldStatus.BuildStatusEnum ||
                                             newStatus.StartedTime != oldStatus.StartedTime
                                        select newStatus;
@@ -38,7 +38,7 @@ namespace SirenOfShame.Lib.Util
         {
             if (x == null && y == null) return true;
             if (x == null || y == null) return false;
-            return x.BuildId == y.BuildId;
+            return x.UniqueId == y.UniqueId;
         }
 
         public int GetHashCode(BuildStatus obj)

--- a/SirenOfShame.Lib/Watcher/BuildStatus.cs
+++ b/SirenOfShame.Lib/Watcher/BuildStatus.cs
@@ -86,6 +86,15 @@ namespace SirenOfShame.Lib.Watcher
         public string BuildStatusMessage { get; set; }
         public string Comment { get; set; }
 
+        /// <summary>
+        /// Combines the build definition id and the build id for the purpose of uniquely
+        /// identifying a build in a dictionary and determining if a build is new
+        /// </summary>
+        public string UniqueId
+        {
+            get { return $"{BuildDefinitionId}-{BuildId}"; }
+        }
+
         public string BuildStatusDescription
         {
             get { return BuildStatusToString(BuildStatusEnum); }

--- a/SirenOfShame.Lib/Watcher/RulesEngine.cs
+++ b/SirenOfShame.Lib/Watcher/RulesEngine.cs
@@ -307,7 +307,7 @@ namespace SirenOfShame.Lib.Watcher
             var oldBuildStatus = _previousBuildStatuses;
             _previousBuildStatuses = allBuildStatuses;
             var changedBuildStatuses = from newStatus in allBuildStatuses
-                                       from oldStatus in oldBuildStatus.Where(s => s.BuildId == newStatus.BuildId).DefaultIfEmpty()
+                                       from oldStatus in oldBuildStatus.Where(s => s.UniqueId == newStatus.UniqueId).DefaultIfEmpty()
                                        where DidBuildStatusChange(oldStatus, newStatus)
                                        select newStatus;
             

--- a/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
+++ b/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
@@ -10,7 +10,22 @@ namespace SirenOfShame.Test.Unit.Util
     public class BuildStatusUtilTest
     {
         [Test]
-        public void Merge_NewBuildStatus_Added()
+        public void GivenOneOldStatus_WhenTwoNewBuildsExistWithSameBuildDefinitionId_ThenNewestIsReturned()
+        {
+            var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "BD1", BuildId = "B1", BuildStatusEnum = BuildStatusEnum.Working } };
+            var newStatuses = new[]
+            {
+                new BuildStatus {BuildDefinitionId = "BD1", BuildId = "B2", BuildStatusEnum = BuildStatusEnum.InProgress, StartedTime = new DateTime(2018, 1, 1, 2, 2, 3) },
+                new BuildStatus {BuildDefinitionId = "BD1", BuildId = "B3", BuildStatusEnum = BuildStatusEnum.InProgress, StartedTime = new DateTime(2018, 1, 1, 2, 2, 2)}
+            };
+            var buildStatuses = BuildStatusUtil.Merge(oldStatus, newStatuses);
+            Assert.AreEqual(1, buildStatuses.Length);
+            var buildStatuse = buildStatuses[0];
+            Assert.AreEqual("B2", buildStatuse.BuildId);
+        }
+
+        [Test]
+        public void GivenEmptyOldStatus_WhenNewBuildStatusExists_ThenNewBuildStatusIsAdded()
         {
             var oldStatus = new BuildStatus[] {};
             var newStatuses = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
@@ -21,7 +36,7 @@ namespace SirenOfShame.Test.Unit.Util
         }
         
         [Test]
-        public void Merge_RemovedBuildStatus_Retained()
+        public void GivenAnOldBuildStatus_WhenEmptyNewBuildStatusMerged_ThenOldBuildStatusIsRetained()
         {
             var oldStatus = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
             var newStatuses = new BuildStatus[] {};
@@ -30,7 +45,7 @@ namespace SirenOfShame.Test.Unit.Util
         }
 
         [Test]
-        public void Merge_ExistingUnchangedBuildStatus_NotOverwritten()
+        public void GivenOldBuildStatus_WhenBuildStatusWithSameIdIsMerged_ThenOldBuildStatusIsNotOverwritten()
         {
             var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2010, 1, 1) } };
             var newStatuses = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2012, 2, 2)} };

--- a/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
@@ -10,6 +10,17 @@ namespace SirenOfShame.Test.Unit.Watcher
     public class BuildStatusTest
     {
         [Test]
+        public void UniqueId_ContainsBuildDefinitionAndBuildId()
+        {
+            var buildStatus = new BuildStatus
+            {
+                BuildId = "1",
+                BuildDefinitionId = "2"
+            };
+            Assert.AreEqual("2-1", buildStatus.UniqueId);
+        }
+
+        [Test]
         public void Parse_InvalidDate()
         {
             var actual = BuildStatus.Parse(new [] { "63460976461000000Z", "", "1", "jshimpty" }, "buildid");


### PR DESCRIPTION
PR 121 assumed that BuildId's could be unique across Build Definitions.  This isn't a valid assumption, at least for Jenkins.  I documented the problem in the unit test `GivenTwoBuildsWithSameBuildIdInDifferentBuildDefinitions_ThenTheyAreTreatedSeparately`.

I solved the problem by replacing PR 121's use of BuildId with `UniqueId`, which combines the BuildDefinitionId and the BuildId to solve the problem of simultaneous builds without introducing a problem when build id's are identical across build definitions.

I also retroactively TDD'd some tests for 121, primarily `GivenTwoBuildsStartedAtSameTime_InvokeStatusReturnsTheMostRecent`, to ensure the original problem was documented, and that it stays solved.

@BubbaFatAss: If you don't mind please verify that this works in your environment prior to approval & merge, then I'll merge 121.